### PR TITLE
Fixing ValueError when no detections

### DIFF
--- a/tidecv/quantify.py
+++ b/tidecv/quantify.py
@@ -81,9 +81,11 @@ class TIDEExample:
         for id_d, d in enumerate(detections):
             for id_g, g in enumerate(gt):
                 self.gt_iou[id_d, id_g] = jaccard(d, g)
-        assert (
-            np.amin(self.gt_iou) >= 0.0
-        ), "jaccard array contains values smaller than zero!"
+
+        if len(detections) > 0 and len(gt) > 0:
+            assert (
+                np.amin(self.gt_iou) >= 0.0
+            ), "jaccard array contains values smaller than zero!"
 
         # IoU is [len(detections), len(gt)]
         # self.gt_iou = mask_utils.iou(


### PR DESCRIPTION
Numpy amin method will return a ValueError when the shape of one of the axes in the input array is zero. This happens when there are no detections. 

`ValueError: zero-size array to reduction operation minimum which has no identity`

Changes in this PR have been tested on our test set, and is confirmed to produce same results as vanilla COCO eval from pycocotools.